### PR TITLE
ServerFinder: Addressed a potential race condition.

### DIFF
--- a/app/src/main/java/com/github/oheger/wificontrol/MainActivity.kt
+++ b/app/src/main/java/com/github/oheger/wificontrol/MainActivity.kt
@@ -28,6 +28,7 @@ import androidx.compose.material.Surface
 import androidx.compose.ui.Modifier
 
 import com.github.oheger.wificontrol.ui.theme.WifiControlTheme
+import kotlin.time.Duration.Companion.milliseconds
 
 import kotlin.time.Duration.Companion.seconds
 
@@ -42,7 +43,8 @@ class MainActivity : ComponentActivity() {
             port = 4321,
             requestCode = "playerServer?",
             networkTimeout = 5.seconds,
-            retryDelay = 10.seconds
+            retryDelay = 10.seconds,
+            sendRequestInterval = 100.milliseconds
         )
     }
 


### PR DESCRIPTION
It happened in the past that responses sent by the server were missed. This was probably caused by the receiver not yet ready. To fix this, sender and receiver now run in different coroutines, and the sender sends requests periodically. Thus, if one request is missed, it is likely that the next one is received.