### PR TITLE
Restore the latest control UI on startup

### DIFF
--- a/app/src/main/java/com/github/oheger/wificontrol/controlui/ControlUi.kt
+++ b/app/src/main/java/com/github/oheger/wificontrol/controlui/ControlUi.kt
@@ -108,7 +108,7 @@ fun ControlScreen(
     controlArgs: Navigation.ControlServiceArgs,
     navController: NavController
 ) {
-    viewModel.initControlState(controlArgs.serviceName)
+    viewModel.loadUiState(ControlViewModel.Parameters(controlArgs.serviceName))
     val state: ControlUiState by viewModel.uiStateFlow.collectAsStateWithLifecycle(WiFiUnavailable)
 
     ControlScreenForState(

--- a/app/src/main/java/com/github/oheger/wificontrol/svcui/ServiceDetailsUi.kt
+++ b/app/src/main/java/com/github/oheger/wificontrol/svcui/ServiceDetailsUi.kt
@@ -396,7 +396,7 @@ fun ViewServiceDetailsPreview() {
         lookupTimeout = null,
         sendRequestInterval = null
     )
-    val serviceData = ServiceData(emptyList(), 0)
+    val serviceData = ServiceData(emptyList())
     val state = ServicesUiStateLoaded(ServiceDetailsState(serviceData, 0, service, editMode = false))
 
     WifiControlTheme {
@@ -417,7 +417,7 @@ fun EditServiceDetailsPreview() {
         lookupTimeout = null,
         sendRequestInterval = null
     )
-    val serviceData = ServiceData(emptyList(), 0)
+    val serviceData = ServiceData(emptyList())
     val saveException = IllegalStateException("Could not save service.")
     val detailsState = ServiceDetailsState(serviceData, 0, service, editMode = true, saveException)
     val state = ServicesUiStateLoaded(detailsState)

--- a/app/src/main/java/com/github/oheger/wificontrol/svcui/ServiceDetailsUi.kt
+++ b/app/src/main/java/com/github/oheger/wificontrol/svcui/ServiceDetailsUi.kt
@@ -90,7 +90,7 @@ fun ServiceDetailsScreen(
     serviceDetailsArgs: Navigation.ServiceDetailsArgs,
     navController: NavController
 ) {
-    viewModel.loadService(serviceDetailsArgs.serviceIndex)
+    viewModel.loadUiState(ServiceDetailsViewModel.Parameters(serviceDetailsArgs.serviceIndex))
     val state: ServicesUiState<ServiceDetailsState> by
     viewModel.uiStateFlow.collectAsStateWithLifecycle(ServicesUiStateLoading)
 

--- a/app/src/main/java/com/github/oheger/wificontrol/svcui/ServicesOverviewUi.kt
+++ b/app/src/main/java/com/github/oheger/wificontrol/svcui/ServicesOverviewUi.kt
@@ -327,7 +327,7 @@ fun ServicesListPreview() {
         )
     )
     val state = ServicesOverviewState(
-        ServiceData(services, 0),
+        ServiceData(services),
         IllegalStateException("Error when saving services.")
     )
 
@@ -342,7 +342,7 @@ fun ServicesListPreview() {
 @Composable
 fun ServicesListEmptyPreview() {
     val state = ServicesOverviewState(
-        ServiceData(emptyList(), 0)
+        ServiceData(emptyList())
     )
 
     WifiControlTheme {

--- a/app/src/main/java/com/github/oheger/wificontrol/svcui/ServicesOverviewUi.kt
+++ b/app/src/main/java/com/github/oheger/wificontrol/svcui/ServicesOverviewUi.kt
@@ -43,6 +43,7 @@ import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -85,6 +86,14 @@ fun ServicesOverviewScreen(viewModel: ServicesViewModel, navController: NavContr
     val state: ServicesUiState<ServicesOverviewState> by viewModel.uiStateFlow.collectAsStateWithLifecycle(
         ServicesUiStateLoading
     )
+
+    LaunchedEffect(Unit) {
+        viewModel.currentServiceFlow.collect { currentService ->
+            navController.navigate(
+                Navigation.ControlServiceRoute.forArguments(Navigation.ControlServiceArgs(currentService.serviceName))
+            )
+        }
+    }
 
     ServicesOverviewScreenForState(
         state = state,

--- a/app/src/main/java/com/github/oheger/wificontrol/svcui/ServicesOverviewUi.kt
+++ b/app/src/main/java/com/github/oheger/wificontrol/svcui/ServicesOverviewUi.kt
@@ -82,7 +82,7 @@ internal fun serviceTag(serviceName: String, subTag: String): String = "${servic
  */
 @Composable
 fun ServicesOverviewScreen(viewModel: ServicesViewModel, navController: NavController) {
-    viewModel.loadServices()
+    viewModel.loadUiState(ServicesViewModel.Parameters)
     val state: ServicesUiState<ServicesOverviewState> by viewModel.uiStateFlow.collectAsStateWithLifecycle(
         ServicesUiStateLoading
     )

--- a/app/src/main/java/com/github/oheger/wificontrol/svcui/ServicesViewModel.kt
+++ b/app/src/main/java/com/github/oheger/wificontrol/svcui/ServicesViewModel.kt
@@ -90,6 +90,10 @@ class ServicesViewModel @Inject constructor(
      */
     private var servicesLoaded = false
 
+    /**
+     * A flow that is monitored by the UI in order to receive the most recent UI state. The UI then updates itself
+     * accordingly.
+     */
     val uiStateFlow = mutableUiStateFlow.asStateFlow().combineState(saveErrorFlow) { state, error ->
         state.copy(updateError = error)
     }
@@ -100,6 +104,11 @@ class ServicesViewModel @Inject constructor(
      */
     val currentServiceFlow = mutableCurrentServiceFlow.asSharedFlow()
 
+    /**
+     * Trigger loading of the data that is managed by this view model. This function is called by the UI. It triggers
+     * operations to obtain the services to be displayed. The results are then available via the flows exposed by this
+     * view model.
+     */
     fun loadServices() {
         if (!servicesLoaded) {
             servicesLoaded = true
@@ -122,14 +131,23 @@ class ServicesViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Move the service with the given [serviceName] one position down in the list of services.
+     */
     fun moveServiceDown(serviceName: String) {
         modifyAndSaveData { it.moveDown(serviceName) }
     }
 
+    /**
+     * Move the service with the given [serviceName] one position up in the list of services.
+     */
     fun moveServiceUp(serviceName: String) {
         modifyAndSaveData { it.moveUp(serviceName) }
     }
 
+    /**
+     * Remove the service with the given [serviceName] from the list of services.
+     */
     fun removeService(serviceName: String) {
         modifyAndSaveData { it.removeService(serviceName) }
     }

--- a/app/src/main/java/com/github/oheger/wificontrol/ui/BaseViewModel.kt
+++ b/app/src/main/java/com/github/oheger/wificontrol/ui/BaseViewModel.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2023-2024 Oliver Heger.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.github.oheger.wificontrol.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+
+import com.github.oheger.wificontrol.domain.model.CurrentService
+import com.github.oheger.wificontrol.domain.usecase.StoreCurrentServiceUseCase
+
+import kotlinx.coroutines.launch
+
+/**
+ * A base class for the view models used by this application. This base class provides some common functionality that
+ * is required by each concrete view model implementation:
+ * - It provides a function to load the UI state when the associated UI opens up.
+ * - There is logic to ensure that this load function is only executed once.
+ * - Each screen of the application has to update the name of the currently controlled service. This base class offers
+ *   a function for this purpose and manages the use case required for this.
+ */
+abstract class BaseViewModel<in P : BaseViewModel.Parameters>(
+    /** The use case for storing the currently controlled service in the preferences. */
+    private val storeCurrentServiceUseCase: StoreCurrentServiceUseCase
+) : ViewModel() {
+    /**
+     * A flag to control that the UI state is loaded only once. During recomposition, the [loadUiState]
+     * function can be called multiple times. With this flag, only the first invocation triggers a load of the state.
+     * Note: As all invocations happen on the main dispatcher, there is no need for synchronization.
+     */
+    private var stateLoaded = false
+
+    /**
+     * Initially load the UI state when the associated screen is opened based on the given [parameters]. This function
+     * checks whether this is the first invocation. If so, it delegates to [performLoad]. Further calls are then
+     * ignored.
+     */
+    fun loadUiState(parameters: P) {
+        if (!stateLoaded) {
+            stateLoaded = true
+
+            val currentServiceToUpdate = performLoad(parameters)
+
+            currentServiceToUpdate?.let(this::storeCurrentService)
+        }
+    }
+
+    /**
+     * Update the currently controlled service in the preferences based on the given [currentService].
+     */
+    protected fun storeCurrentService(currentService: CurrentService) {
+        viewModelScope.launch {
+            storeCurrentServiceUseCase.execute(StoreCurrentServiceUseCase.Input(currentService))
+                .collect {}
+        }
+    }
+
+    /**
+     * Perform the actual initialization of this view model based on the given [parameters]. A concrete implementation
+     * typically executes some use cases to obtain the data to be displayed by the UI. If a non-*null*
+     * [CurrentService] is returned, this base class updates the name of the currently controlled service in the
+     * preferences accordingly.
+     */
+    protected abstract fun performLoad(parameters: P): CurrentService?
+
+    /**
+     * A interface defining the parameters required by a specific instance. Such a parameters object is passed to the
+     * [loadUiState] function.
+     */
+    interface Parameters
+}

--- a/app/src/test/java/com/github/oheger/wificontrol/svcui/CreateServiceUiTest.kt
+++ b/app/src/test/java/com/github/oheger/wificontrol/svcui/CreateServiceUiTest.kt
@@ -91,7 +91,7 @@ class CreateServiceUiTest {
         }
         storeUseCase = mockk()
         navController = mockk()
-        val viewModel = ServiceDetailsViewModel(loadUseCase, storeUseCase)
+        val viewModel = ServiceDetailsViewModel(loadUseCase, storeUseCase, mockk(relaxed = true))
 
         composeTestRule.setContent {
             ServiceDetailsScreen(

--- a/app/src/test/java/com/github/oheger/wificontrol/svcui/CreateServiceUiTest.kt
+++ b/app/src/test/java/com/github/oheger/wificontrol/svcui/CreateServiceUiTest.kt
@@ -82,7 +82,7 @@ class CreateServiceUiTest {
             lookupTimeout = null,
             sendRequestInterval = null
         )
-        serviceData = ServiceData(listOf(testService), 0)
+        serviceData = ServiceData(listOf(testService))
 
         val loadUseCase = mockk<LoadServiceUseCase> {
             every {

--- a/app/src/test/java/com/github/oheger/wificontrol/svcui/ServiceDetailsUiTest.kt
+++ b/app/src/test/java/com/github/oheger/wificontrol/svcui/ServiceDetailsUiTest.kt
@@ -95,7 +95,7 @@ class ServiceDetailsUiTest {
      * load service use case.
      */
     private suspend fun initService(service: PersistentService): LoadServiceUseCase.Output {
-        val serviceData = ServiceData(listOf(service), 0)
+        val serviceData = ServiceData(listOf(service))
         val loadResult = LoadServiceUseCase.Output(serviceData, service)
 
         initLoadResult(Result.success(loadResult))

--- a/app/src/test/java/com/github/oheger/wificontrol/svcui/ServiceDetailsViewModelTest.kt
+++ b/app/src/test/java/com/github/oheger/wificontrol/svcui/ServiceDetailsViewModelTest.kt
@@ -19,7 +19,9 @@
 package com.github.oheger.wificontrol.svcui
 
 import com.github.oheger.wificontrol.domain.model.ServiceData
+import com.github.oheger.wificontrol.domain.model.UndefinedCurrentService
 import com.github.oheger.wificontrol.domain.usecase.LoadServiceUseCase
+import com.github.oheger.wificontrol.domain.usecase.StoreCurrentServiceUseCase
 
 import io.kotest.core.spec.style.StringSpec
 
@@ -58,7 +60,12 @@ class ServiceDetailsViewModelTest : StringSpec({
         val loadUseCase = mockk<LoadServiceUseCase> {
             every { execute(expectedInput) } returns flowOf(Result.success(loadResult))
         }
-        val viewModel = ServiceDetailsViewModel(loadUseCase, mockk())
+        val storeCurrentServiceUseCase = mockk<StoreCurrentServiceUseCase> {
+            every {
+                execute(StoreCurrentServiceUseCase.Input(UndefinedCurrentService))
+            } returns flowOf(Result.failure(IllegalArgumentException("Test exception: store current service.")))
+        }
+        val viewModel = ServiceDetailsViewModel(loadUseCase, mockk(), storeCurrentServiceUseCase)
 
         viewModel.loadService(serviceIndex)
         viewModel.uiStateFlow.first()
@@ -66,6 +73,7 @@ class ServiceDetailsViewModelTest : StringSpec({
 
         verify(exactly = 1, timeout = 3000) {
             loadUseCase.execute(expectedInput)
+            storeCurrentServiceUseCase.execute(StoreCurrentServiceUseCase.Input(UndefinedCurrentService))
         }
     }
 })

--- a/app/src/test/java/com/github/oheger/wificontrol/svcui/ServiceDetailsViewModelTest.kt
+++ b/app/src/test/java/com/github/oheger/wificontrol/svcui/ServiceDetailsViewModelTest.kt
@@ -55,6 +55,7 @@ class ServiceDetailsViewModelTest : StringSpec({
 
     "Data about the current service should only be loaded once" {
         val serviceIndex = 23
+        val parameters = ServiceDetailsViewModel.Parameters(serviceIndex)
         val expectedInput = LoadServiceUseCase.Input(serviceIndex)
         val loadResult = LoadServiceUseCase.Output(ServiceData(emptyList()), mockk())
         val loadUseCase = mockk<LoadServiceUseCase> {
@@ -67,9 +68,9 @@ class ServiceDetailsViewModelTest : StringSpec({
         }
         val viewModel = ServiceDetailsViewModel(loadUseCase, mockk(), storeCurrentServiceUseCase)
 
-        viewModel.loadService(serviceIndex)
+        viewModel.loadUiState(parameters)
         viewModel.uiStateFlow.first()
-        viewModel.loadService(serviceIndex)
+        viewModel.loadUiState(parameters)
 
         verify(exactly = 1, timeout = 3000) {
             loadUseCase.execute(expectedInput)

--- a/app/src/test/java/com/github/oheger/wificontrol/svcui/ServiceDetailsViewModelTest.kt
+++ b/app/src/test/java/com/github/oheger/wificontrol/svcui/ServiceDetailsViewModelTest.kt
@@ -54,7 +54,7 @@ class ServiceDetailsViewModelTest : StringSpec({
     "Data about the current service should only be loaded once" {
         val serviceIndex = 23
         val expectedInput = LoadServiceUseCase.Input(serviceIndex)
-        val loadResult = LoadServiceUseCase.Output(ServiceData(emptyList(), 0), mockk())
+        val loadResult = LoadServiceUseCase.Output(ServiceData(emptyList()), mockk())
         val loadUseCase = mockk<LoadServiceUseCase> {
             every { execute(expectedInput) } returns flowOf(Result.success(loadResult))
         }

--- a/app/src/test/java/com/github/oheger/wificontrol/svcui/ServicesOverviewUiTest.kt
+++ b/app/src/test/java/com/github/oheger/wificontrol/svcui/ServicesOverviewUiTest.kt
@@ -36,7 +36,6 @@ import com.github.oheger.wificontrol.domain.usecase.StoreServiceDataUseCase
 
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.shouldContainExactly
-import io.kotest.matchers.shouldBe
 
 import io.mockk.every
 import io.mockk.just
@@ -140,7 +139,6 @@ class ServicesOverviewUiTest {
             .performClick()
         val savedData = expectStoredData()
 
-        savedData.currentIndex shouldBe data.currentIndex
         savedData.services shouldContainExactly listOf(data.services[1], data.services[0])
     }
 
@@ -160,7 +158,6 @@ class ServicesOverviewUiTest {
             .performClick()
         val savedData = expectStoredData()
 
-        savedData.currentIndex shouldBe data.currentIndex
         savedData.services shouldContainExactly listOf(data.services[1], data.services[0])
     }
 
@@ -180,7 +177,6 @@ class ServicesOverviewUiTest {
             .performClick()
         val savedData = expectStoredData()
 
-        savedData.currentIndex shouldBe data.currentIndex
         savedData.services shouldContainExactly listOf(data.services[1], data.services[2])
     }
 
@@ -288,5 +284,5 @@ private fun createService(index: Int): PersistentService {
  */
 private fun createServiceData(serviceCount: Int): ServiceData {
     val services = (1..serviceCount).map(::createService)
-    return ServiceData(services, 0)
+    return ServiceData(services)
 }

--- a/app/src/test/java/com/github/oheger/wificontrol/svcui/ServicesViewModelTest.kt
+++ b/app/src/test/java/com/github/oheger/wificontrol/svcui/ServicesViewModelTest.kt
@@ -55,7 +55,7 @@ class ServicesViewModelTest : StringSpec({
         val loadUseCase = mockk<LoadServiceDataUseCase> {
             every {
                 execute(LoadServiceDataUseCase.Input)
-            } returns flowOf(Result.success(LoadServiceDataUseCase.Output(ServiceData(emptyList(), 0))))
+            } returns flowOf(Result.success(LoadServiceDataUseCase.Output(ServiceData(emptyList()))))
         }
         val viewModel = ServicesViewModel(loadUseCase, mockk())
 

--- a/app/src/test/java/com/github/oheger/wificontrol/svcui/ServicesViewModelTest.kt
+++ b/app/src/test/java/com/github/oheger/wificontrol/svcui/ServicesViewModelTest.kt
@@ -70,13 +70,13 @@ class ServicesViewModelTest : StringSpec({
         }
         val viewModel = ServicesViewModel(loadUseCase, mockk(), loadCurrentServiceUseCase, storeCurrentServiceUseCase)
 
-        viewModel.loadServices()
+        viewModel.loadUiState(ServicesViewModel.Parameters)
         viewModel.uiStateFlow.first()
         verify(timeout = 3000) {
             storeCurrentServiceUseCase.execute(StoreCurrentServiceUseCase.Input(UndefinedCurrentService))
         }
 
-        viewModel.loadServices()
+        viewModel.loadUiState(ServicesViewModel.Parameters)
 
         verify(exactly = 1, timeout = 3000) {
             loadUseCase.execute(LoadServiceDataUseCase.Input)

--- a/app/src/test/java/com/github/oheger/wificontrol/svcui/ServicesViewModelTest.kt
+++ b/app/src/test/java/com/github/oheger/wificontrol/svcui/ServicesViewModelTest.kt
@@ -57,7 +57,7 @@ class ServicesViewModelTest : StringSpec({
                 execute(LoadServiceDataUseCase.Input)
             } returns flowOf(Result.success(LoadServiceDataUseCase.Output(ServiceData(emptyList()))))
         }
-        val viewModel = ServicesViewModel(loadUseCase, mockk())
+        val viewModel = ServicesViewModel(loadUseCase, mockk(), mockk())
 
         viewModel.loadServices()
         viewModel.uiStateFlow.first()

--- a/domain/src/main/java/com/github/oheger/wificontrol/domain/model/CurrentService.kt
+++ b/domain/src/main/java/com/github/oheger/wificontrol/domain/model/CurrentService.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023-2024 Oliver Heger.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.github.oheger.wificontrol.domain.model
+
+/**
+ * The root of a class hierarchy that represents the service that is currently controlled by the app. This data is
+ * persisted, so that on reopening the app, this service can directly be loaded and displayed. There are two subtypes
+ * of this interface: one for a defined current service, and one for an undefined one. The latter is used when the
+ * app was closed and another screen than a service control UI was active.
+ */
+sealed interface CurrentService {
+    companion object {
+        /**
+         * Return a [CurrentService] instance based on the provided [serviceName]. The correct subtype is chosen based
+         * on the fact whether the name is *null* or not.
+         */
+        fun forServiceName(serviceName: String?): CurrentService =
+            serviceName?.let(::DefinedCurrentService) ?: UndefinedCurrentService
+    }
+}
+
+/**
+ * A data class representing a defined current service. An instance holds the name of this service.
+ */
+data class DefinedCurrentService(
+    /** The name of the current service. */
+    val serviceName: String
+) : CurrentService
+
+/**
+ * An object to represent the state that no service is currently controlled by this app.
+ */
+data object UndefinedCurrentService : CurrentService

--- a/domain/src/main/java/com/github/oheger/wificontrol/domain/model/ServiceData.kt
+++ b/domain/src/main/java/com/github/oheger/wificontrol/domain/model/ServiceData.kt
@@ -24,10 +24,7 @@ package com.github.oheger.wificontrol.domain.model
  */
 data class ServiceData(
     /** A list with the persistent services managed by this class. */
-    val services: List<PersistentService>,
-
-    /** The index of the current service. This is the last service the user interacted with. */
-    val currentIndex: Int
+    val services: List<PersistentService>
 ) {
     companion object {
         /**
@@ -37,12 +34,6 @@ data class ServiceData(
          */
         const val NEW_SERVICE_INDEX = -1
     }
-
-    /**
-     * Return a [LookupService] object for the currently selected service or *null* if nothing is selected.
-     */
-    val current: LookupService?
-        get() = currentIndex.takeIf { it < services.size && it >= 0 }?.let(this::get)
 
     /**
      * Return a [LookupService] object for the managed service at the given [index].
@@ -103,9 +94,7 @@ data class ServiceData(
             "A service with the name '$serviceName' does not exist."
         }
 
-        val newCurrent = if (current?.service?.name == serviceName) 0 else currentIndex
-
-        return copy(services = newServices, currentIndex = newCurrent)
+        return copy(services = newServices)
     }
 
     /**
@@ -148,14 +137,6 @@ data class ServiceData(
         indexOfOrThrow(serviceName).takeIf { it < services.size - 1 }?.let { pos ->
             swapServices(pos, pos + 1)
         } ?: this
-
-    /**
-     * Return a new [ServiceData] instance that has the the service with the given [serviceName] selected as the
-     * current one. This is then the one which is displayed by the app. Throw an [IllegalArgumentException] if no
-     * service with this name exists.
-     */
-    fun makeCurrent(serviceName: String): ServiceData =
-        takeIf { current?.service?.name == serviceName } ?: copy(currentIndex = indexOfOrThrow(serviceName))
 
     /**
      * Return a new instance of [ServiceData] in which the services at the given positions [pos1] and [pos2] are

--- a/domain/src/main/java/com/github/oheger/wificontrol/domain/repo/CurrentServiceRepository.kt
+++ b/domain/src/main/java/com/github/oheger/wificontrol/domain/repo/CurrentServiceRepository.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023-2024 Oliver Heger.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.github.oheger.wificontrol.domain.repo
+
+import com.github.oheger.wificontrol.domain.model.CurrentService
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Definition of a repository interface for managing the service that is currently controlled.
+ *
+ * The current service is persisted, so that its control UI can be loaded and opened directly when the app is
+ * restarted. This is rather useful if the user only deals with few services.
+ */
+interface CurrentServiceRepository {
+    /**
+     * Return a [Flow] with the persisted current service controlled by this application. Note that the primary use
+     * case for this function is to restore the control UI of the current service when the app is started. This is not
+     * used for navigation when the user switches to another service.
+     */
+    fun getCurrentService(): Flow<CurrentService>
+
+    /**
+     * Persist the given [currentService], so that its control UI can be restored when the app is closed and restarted.
+     * This function is typically invoked every time the control UI is opened with the currently active service; and
+     * also to clear this information when a different screen is shown.
+     */
+    fun setCurrentService(currentService: CurrentService): Flow<CurrentService>
+}

--- a/domain/src/main/java/com/github/oheger/wificontrol/domain/usecase/BaseUseCase.kt
+++ b/domain/src/main/java/com/github/oheger/wificontrol/domain/usecase/BaseUseCase.kt
@@ -35,12 +35,17 @@ abstract class BaseUseCase<in I : BaseUseCase.Input, out O : BaseUseCase.Output>
     /** The configuration for this use case. */
     private val config: UseCaseConfig
 ) {
+    companion object {
+        /** A tag for logging information related to use cases. */
+        const val TAG = "UseCase"
+    }
+
     /**
      * Execute this use case with the given [input]. Return a [Flow] with the resulting data wrapped in a [Result].
      */
     fun execute(input: I): Flow<Result<O>> {
         Log.i(
-            "UseCase",
+            TAG,
             "Executing use case ${this::class.simpleName} with input $input on " +
                     "${Thread.currentThread().name}."
         )
@@ -50,8 +55,9 @@ abstract class BaseUseCase<in I : BaseUseCase.Input, out O : BaseUseCase.Output>
                 Result.success(result)
             }
             .flowOn(config.dispatcher)
-            .catch {
-                emit(Result.failure(it))
+            .catch { exception ->
+                Log.e(TAG, "Error when executing use case ${this::class.simpleName}.", exception)
+                emit(Result.failure(exception))
             }
     }
 

--- a/domain/src/main/java/com/github/oheger/wificontrol/domain/usecase/LoadCurrentServiceUseCase.kt
+++ b/domain/src/main/java/com/github/oheger/wificontrol/domain/usecase/LoadCurrentServiceUseCase.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023-2024 Oliver Heger.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.github.oheger.wificontrol.domain.usecase
+
+import com.github.oheger.wificontrol.domain.model.CurrentService
+import com.github.oheger.wificontrol.domain.repo.CurrentServiceRepository
+
+import javax.inject.Inject
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+/**
+ * A use case for loading the [CurrentService] from the corresponding repository.
+ */
+class LoadCurrentServiceUseCase @Inject constructor(
+    config: UseCaseConfig,
+
+    /** The repository to manage the current service of this app. */
+    private val currentServiceRepository: CurrentServiceRepository
+) : BaseUseCase<LoadCurrentServiceUseCase.Input, LoadCurrentServiceUseCase.Output>(config) {
+    override fun process(input: Input): Flow<Output> =
+        currentServiceRepository.getCurrentService().map(::Output)
+
+    /**
+     * The type of the input of this use case. This use case does not require any input.
+     */
+    data object Input : BaseUseCase.Input
+
+    /**
+     * The type of the output of this use case. Here the current service is returned which may be defined or undefined.
+     */
+    data class Output(
+        /** The currently controlled service. */
+        val currentService: CurrentService
+    ) : BaseUseCase.Output
+}

--- a/domain/src/main/java/com/github/oheger/wificontrol/domain/usecase/StoreCurrentServiceUseCase.kt
+++ b/domain/src/main/java/com/github/oheger/wificontrol/domain/usecase/StoreCurrentServiceUseCase.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023-2024 Oliver Heger.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.github.oheger.wificontrol.domain.usecase
+
+import com.github.oheger.wificontrol.domain.model.CurrentService
+import com.github.oheger.wificontrol.domain.repo.CurrentServiceRepository
+
+import javax.inject.Inject
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+/**
+ * A use case for storing the [CurrentService] in the corresponding repository. The use case is invoked by every
+ * screen to keep track on the currently controlled service, so that the control UI can be restored when starting the
+ * app.
+ */
+class StoreCurrentServiceUseCase @Inject constructor(
+    useCaseConfig: UseCaseConfig,
+
+    /** The repository for storing the current service. */
+    private val currentServiceRepository: CurrentServiceRepository
+) : BaseUseCase<StoreCurrentServiceUseCase.Input, StoreCurrentServiceUseCase.Output>(useCaseConfig) {
+    override fun process(input: Input): Flow<Output> =
+        currentServiceRepository.setCurrentService(input.currentService).map { Output }
+
+    /**
+     * The type of the input of this use case. This is the service to be stored.
+     */
+    data class Input(
+        /** The current service to be persisted. */
+        val currentService: CurrentService
+    ) : BaseUseCase.Input
+
+    /**
+     * The type of the output of this use case. Here no data is returned.
+     */
+    data object Output : BaseUseCase.Output
+}

--- a/domain/src/test/java/com/github/oheger/wificontrol/domain/model/CurrentServiceTest.kt
+++ b/domain/src/test/java/com/github/oheger/wificontrol/domain/model/CurrentServiceTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023-2024 Oliver Heger.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.github.oheger.wificontrol.domain.model
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+class CurrentServiceTest : WordSpec({
+    "forServiceName" should {
+        "return a defined service if a name is given" {
+            val serviceName = "ThisIsAWellDefinedService"
+
+            val currentService = CurrentService.forServiceName(serviceName)
+
+            currentService shouldBe DefinedCurrentService(serviceName)
+        }
+
+        "return an undefined service for a null name" {
+            val currentService = CurrentService.forServiceName(null)
+
+            currentService shouldBe UndefinedCurrentService
+        }
+    }
+})

--- a/domain/src/test/java/com/github/oheger/wificontrol/domain/model/ServiceDataTest.kt
+++ b/domain/src/test/java/com/github/oheger/wificontrol/domain/model/ServiceDataTest.kt
@@ -129,26 +129,6 @@ class ServiceDataTest : WordSpec({
         }
     }
 
-    "current" should {
-        "return null if the selected index is larger than the number of services" {
-            val data = ServiceData(emptyList(), 0)
-
-            data.current should beNull()
-        }
-
-        "return null if the selected index is less than zero" {
-            val data = createServiceData(current = -1)
-
-            data.current should beNull()
-        }
-
-        "return the service at the current index" {
-            val data = createServiceData(1)
-
-            data.current shouldBe data[1]
-        }
-    }
-
     "contains" should {
         "return true for an existing service" {
             val data = createServiceData()
@@ -175,12 +155,11 @@ class ServiceDataTest : WordSpec({
                 lookupTimeout = 11.seconds,
                 sendRequestInterval = 44.milliseconds
             )
-            val data = createServiceData(current = 1)
+            val data = createServiceData()
 
             val newData = data.addService(newService)
 
             newData.services[2] shouldBe newService
-            newData.currentIndex shouldBe data.currentIndex
         }
 
         "throw an exception if there is a service with the given name" {
@@ -199,7 +178,6 @@ class ServiceDataTest : WordSpec({
 
             val newData = data.removeService(service2.name)
 
-            newData.currentIndex shouldBe data.currentIndex
             newData.services shouldContainExactly listOf(persistentService1)
         }
 
@@ -211,14 +189,6 @@ class ServiceDataTest : WordSpec({
                 data.removeService(nonExistingService)
             }
             exception.message shouldContain nonExistingService
-        }
-
-        "reset the current index if the current service is removed" {
-            val data = createServiceData(current = 1)
-
-            val newData = data.removeService(service2.name)
-
-            newData.currentIndex shouldBe 0
         }
     }
 
@@ -327,34 +297,6 @@ class ServiceDataTest : WordSpec({
             newData should beTheSameInstanceAs(data)
         }
     }
-
-    "makeCurrent" should {
-        "correctly set the current index" {
-            val data = createServiceData(current = 1)
-
-            val newData = data.makeCurrent(service1.name)
-
-            newData.currentIndex shouldBe 0
-        }
-
-        "throw an exception if no service with this name exists" {
-            val nonExistingService = "thisServiceCannotBeTheCurrentOne"
-            val data = createServiceData()
-
-            val exception = shouldThrow<IllegalArgumentException> {
-                data.makeCurrent(nonExistingService)
-            }
-            exception.message shouldContain nonExistingService
-        }
-
-        "return the same instance if the service is already the current one" {
-            val data = createServiceData(current = 0)
-
-            val newData = data.makeCurrent(service1.name)
-
-            newData should beTheSameInstanceAs(data)
-        }
-    }
 })
 
 /** A test service definition. */
@@ -388,10 +330,7 @@ private val persistentService2 = PersistentService(
 )
 
 /**
- * Create a [ServiceData] instance with the test services and the given [current] index.
+ * Create a [ServiceData] instance with test services.
  */
-private fun createServiceData(current: Int = 0): ServiceData =
-    ServiceData(
-        services = listOf(persistentService1, persistentService2),
-        currentIndex = current
-    )
+private fun createServiceData(): ServiceData =
+    ServiceData(services = listOf(persistentService1, persistentService2))

--- a/domain/src/test/java/com/github/oheger/wificontrol/domain/usecase/LoadCurrentServiceUseCaseTest.kt
+++ b/domain/src/test/java/com/github/oheger/wificontrol/domain/usecase/LoadCurrentServiceUseCaseTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2023-2024 Oliver Heger.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.github.oheger.wificontrol.domain.usecase
+
+import com.github.oheger.wificontrol.domain.model.DefinedCurrentService
+import com.github.oheger.wificontrol.domain.repo.CurrentServiceRepository
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.result.shouldBeFailure
+import io.kotest.matchers.result.shouldBeSuccess
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+import io.mockk.every
+import io.mockk.mockk
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+
+class LoadCurrentServiceUseCaseTest : StringSpec({
+    "The current service should be loaded from the repository" {
+        val currentService = DefinedCurrentService("someService")
+        val repository = mockk<CurrentServiceRepository> {
+            every { getCurrentService() } returns flowOf(currentService)
+        }
+
+        val useCase = LoadCurrentServiceUseCase(useCaseConfig, repository)
+        val result = useCase.execute(LoadCurrentServiceUseCase.Input).first()
+
+        result.shouldBeSuccess(LoadCurrentServiceUseCase.Output(currentService))
+    }
+
+    "Exceptions thrown by the repository should be handled" {
+        val exception = IllegalStateException("Test exception: Failed to get current service.")
+        val repository = mockk<CurrentServiceRepository> {
+            every { getCurrentService() } returns flow { throw exception }
+        }
+
+        val useCase = LoadCurrentServiceUseCase(useCaseConfig, repository)
+        val result = useCase.execute(LoadCurrentServiceUseCase.Input).first()
+
+        result.shouldBeFailure { actualException ->
+            actualException.shouldBeInstanceOf<IllegalStateException>()
+            actualException.message shouldBe exception.message
+        }
+    }
+})
+
+/** The default configuration for test use case instances. */
+private val useCaseConfig = UseCaseConfig(Dispatchers.Unconfined)

--- a/domain/src/test/java/com/github/oheger/wificontrol/domain/usecase/LoadServiceByNameUseCaseTest.kt
+++ b/domain/src/test/java/com/github/oheger/wificontrol/domain/usecase/LoadServiceByNameUseCaseTest.kt
@@ -118,6 +118,5 @@ private fun createServiceData(vararg services: LookupService): ServiceData =
                 lookupTimeout = null,
                 sendRequestInterval = null
             )
-        },
-        0
+        }
     )

--- a/domain/src/test/java/com/github/oheger/wificontrol/domain/usecase/LoadServiceUseCaseTest.kt
+++ b/domain/src/test/java/com/github/oheger/wificontrol/domain/usecase/LoadServiceUseCaseTest.kt
@@ -41,7 +41,7 @@ import kotlinx.coroutines.flow.flowOf
 class LoadServiceUseCaseTest : StringSpec({
     "A service should be loaded successfully" {
         val service = createService(1)
-        val serviceData = ServiceData(listOf(createService(0), service, createService(2)), 0)
+        val serviceData = ServiceData(listOf(createService(0), service, createService(2)))
         val loadDataUseCase = mockk<LoadServiceDataUseCase> {
             every {
                 process(LoadServiceDataUseCase.Input)
@@ -55,7 +55,7 @@ class LoadServiceUseCaseTest : StringSpec({
     }
 
     "The index for a new service should be handled correctly" {
-        val serviceData = ServiceData(listOf(createService(1), createService(2)), 0)
+        val serviceData = ServiceData(listOf(createService(1), createService(2)))
         val loadDataUseCase = mockk<LoadServiceDataUseCase> {
             every {
                 process(LoadServiceDataUseCase.Input)
@@ -77,7 +77,7 @@ class LoadServiceUseCaseTest : StringSpec({
 
     "A non existing service should cause a failure result" {
         val nonExistingIndex = 42
-        val serviceData = ServiceData(listOf(createService(1), createService(2)), 1)
+        val serviceData = ServiceData(listOf(createService(1), createService(2)))
         val loadDataUseCase = mockk<LoadServiceDataUseCase> {
             every {
                 process(LoadServiceDataUseCase.Input)

--- a/domain/src/test/java/com/github/oheger/wificontrol/domain/usecase/StoreCurrentServiceUseCaseTest.kt
+++ b/domain/src/test/java/com/github/oheger/wificontrol/domain/usecase/StoreCurrentServiceUseCaseTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023-2024 Oliver Heger.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.github.oheger.wificontrol.domain.usecase
+
+import com.github.oheger.wificontrol.domain.model.DefinedCurrentService
+import com.github.oheger.wificontrol.domain.model.UndefinedCurrentService
+import com.github.oheger.wificontrol.domain.repo.CurrentServiceRepository
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.result.shouldBeSuccess
+
+import io.mockk.every
+import io.mockk.mockk
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+
+class StoreCurrentServiceUseCaseTest : StringSpec({
+    "The current service should be stored" {
+        val currentService = DefinedCurrentService("serviceToBeStored")
+        val repository = mockk<CurrentServiceRepository> {
+            every { setCurrentService(currentService) } returns flowOf(UndefinedCurrentService)
+        }
+
+        val useCase = StoreCurrentServiceUseCase(UseCaseConfig(Dispatchers.IO), repository)
+        val result = useCase.execute(StoreCurrentServiceUseCase.Input(currentService)).first()
+
+        result.shouldBeSuccess(StoreCurrentServiceUseCase.Output)
+    }
+})

--- a/domain/src/test/java/com/github/oheger/wificontrol/domain/usecase/StoreServiceUseCaseTest.kt
+++ b/domain/src/test/java/com/github/oheger/wificontrol/domain/usecase/StoreServiceUseCaseTest.kt
@@ -114,7 +114,7 @@ class StoreServiceUseCaseTest : StringSpec({
     }
 
     "An exception thrown by the ServiceData is handled" {
-        val serviceData = ServiceData(emptyList(), 0)
+        val serviceData = ServiceData(emptyList())
 
         val input = StoreServiceUseCase.Input(serviceData, mockk(), 1)
         val useCase = StoreServiceUseCase(useCaseConfig, mockk(), mockk())
@@ -134,7 +134,7 @@ class StoreServiceUseCaseTest : StringSpec({
             lookupTimeout = null,
             sendRequestInterval = null
         )
-        val serviceData = ServiceData(listOf(service), 0)
+        val serviceData = ServiceData(listOf(service))
 
         val expException = IllegalArgumentException("Could not store service data.")
         val storeDataUseCase = mockk<StoreServiceDataUseCase> {
@@ -166,7 +166,7 @@ class StoreServiceUseCaseTest : StringSpec({
             lookupTimeout = null,
             sendRequestInterval = null
         )
-        val serviceData = ServiceData(listOf(service), 0)
+        val serviceData = ServiceData(listOf(service))
 
         val expException = IllegalArgumentException("Could not store service data.")
         val clearUseCase = mockk<ClearServiceUriUseCase> {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,6 +48,7 @@ androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", versi
 androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "composeUi" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
 androidx-datastore = { module = "androidx.datastore:datastore", version.ref = "androidXDataStore" }
+androidx-datastore-pref = { module = "androidx.datastore:datastore-preferences", version.ref = "androidXDataStore" }
 androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycleRuntime" }
 androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycleRuntime" }
 androidx-test-espresso = { module = "androidx.test.espresso:espresso-core", version.ref = "testEspresso" }

--- a/persistence/build.gradle.kts
+++ b/persistence/build.gradle.kts
@@ -95,6 +95,7 @@ dependencies {
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.datastore)
+    implementation(libs.androidx.datastore.pref)
     implementation(libs.hilt.android)
     implementation(libs.protobufJavaLite)
 

--- a/persistence/src/main/java/com/github/oheger/wificontrol/persistence/di/DataSourceModule.kt
+++ b/persistence/src/main/java/com/github/oheger/wificontrol/persistence/di/DataSourceModule.kt
@@ -18,7 +18,9 @@
  */
 package com.github.oheger.wificontrol.persistence.di
 
+import com.github.oheger.wificontrol.persistence.source.CurrentServiceDataSourceImpl
 import com.github.oheger.wificontrol.persistence.source.ServicesDataSourceImpl
+import com.github.oheger.wificontrol.repository.ds.CurrentServiceDataSource
 import com.github.oheger.wificontrol.repository.ds.ServicesDataSource
 
 import dagger.Binds
@@ -34,4 +36,9 @@ import dagger.hilt.components.SingletonComponent
 abstract class DataSourceModule {
     @Binds
     abstract fun servicesDataSource(servicesDataSourceImpl: ServicesDataSourceImpl): ServicesDataSource
+
+    @Binds
+    abstract fun currentServiceDataSource(
+        currentServiceDataSourceImpl: CurrentServiceDataSourceImpl
+    ): CurrentServiceDataSource
 }

--- a/persistence/src/main/java/com/github/oheger/wificontrol/persistence/di/PersistenceModule.kt
+++ b/persistence/src/main/java/com/github/oheger/wificontrol/persistence/di/PersistenceModule.kt
@@ -21,7 +21,10 @@ package com.github.oheger.wificontrol.persistence.di
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.dataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
 
+import com.github.oheger.wificontrol.persistence.source.CurrentServiceDataSourceImpl
 import com.github.oheger.wificontrol.persistence.source.PersistentServiceData
 import com.github.oheger.wificontrol.persistence.source.PersistentServiceDataSerializer
 import com.github.oheger.wificontrol.persistence.source.ServicesDataSourceImpl
@@ -44,6 +47,11 @@ private val Context.serviceDataStore: DataStore<PersistentServiceData> by dataSt
 )
 
 /**
+ * Extension property to obtain the data store for preferences.
+ */
+private val Context.preferencesDataStore: DataStore<Preferences> by preferencesDataStore(name = "WiFiControlSettings")
+
+/**
  * Hilt module that provides the dependencies for data source implementations.
  */
 @Module
@@ -52,4 +60,8 @@ class PersistenceModule {
     @Provides
     fun servicesDataSourceImpl(@ApplicationContext context: Context): ServicesDataSourceImpl =
         ServicesDataSourceImpl(context.serviceDataStore)
+
+    @Provides
+    fun currentServiceDataSourceImpl(@ApplicationContext context: Context): CurrentServiceDataSourceImpl =
+        CurrentServiceDataSourceImpl(context.preferencesDataStore)
 }

--- a/persistence/src/main/java/com/github/oheger/wificontrol/persistence/source/CurrentServiceDataSourceImpl.kt
+++ b/persistence/src/main/java/com/github/oheger/wificontrol/persistence/source/CurrentServiceDataSourceImpl.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2023-2024 Oliver Heger.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.github.oheger.wificontrol.persistence.source
+
+import android.util.Log
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+
+import com.github.oheger.wificontrol.repository.ds.CurrentServiceDataSource
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+
+/**
+ * An implementation of the [CurrentServiceDataSource] interface based on Preferences DataStore. This implementation
+ * persists the currently controlled service by storing its name (or nothing if there is no current service) as a
+ * string property in the preferences. The service name is only loaded once on the first invocation of the load
+ * function.
+ */
+class CurrentServiceDataSourceImpl(
+    /** The object for storing key value pairs. */
+    private val dataStore: DataStore<Preferences>
+) : CurrentServiceDataSource {
+    companion object {
+        /** Constant for the key that stores the name of the current service. */
+        internal val CURRENT_SERVICE_NAME_KEY = stringPreferencesKey("currentServiceName")
+
+        /** A tag for logging. */
+        private const val TAG = "CurrentServiceDataSourceImpl"
+
+        /**
+         * An internal flow that records whether the current service has already been retrieved. This is used to
+         * implement the functionality that [loadCurrentServiceOnStartup] only once queries the [DataStore] and
+         * afterward returns an empty flow.
+         */
+        private val invocationOnStartup = MutableStateFlow(true)
+
+        /**
+         * Reset the [invocationOnStartup] flow. This is needed for testing only.
+         */
+        internal fun resetInvocationOnStartup() {
+            invocationOnStartup.value = true
+        }
+    }
+
+    override fun loadCurrentServiceOnStartup(): Flow<String?> = flow {
+        if(invocationOnStartup.compareAndSet(expect = true, update = false)) {
+            Log.i(TAG, "Loading the current service from preferences.")
+
+            emitAll(
+                dataStore.data.map { preferences ->
+                    preferences[CURRENT_SERVICE_NAME_KEY]
+                }
+            )
+        }
+    }
+
+    override suspend fun saveCurrentService(serviceName: String?) {
+        Log.i(TAG, "Updating the current service to '$serviceName'.")
+
+        dataStore.edit { preferences ->
+            if(serviceName != null) {
+                preferences[CURRENT_SERVICE_NAME_KEY] = serviceName
+            } else {
+                preferences.remove(CURRENT_SERVICE_NAME_KEY)
+            }
+        }
+    }
+}

--- a/persistence/src/main/java/com/github/oheger/wificontrol/persistence/source/ServicesDataSourceImpl.kt
+++ b/persistence/src/main/java/com/github/oheger/wificontrol/persistence/source/ServicesDataSourceImpl.kt
@@ -41,8 +41,7 @@ class ServicesDataSourceImpl(
     override fun loadServiceData(): Flow<ServiceData> =
         dataStore.data.map { persistentData ->
             ServiceData(
-                services = persistentData.serviceDefinitionsList.map(::toDomainService),
-                currentIndex = persistentData.currentIndex
+                services = persistentData.serviceDefinitionsList.map(::toDomainService)
             )
         }
 
@@ -50,7 +49,6 @@ class ServicesDataSourceImpl(
         dataStore.updateData {
             val services = data.services.map(::toPersistentService)
             PersistentServiceData.newBuilder()
-                .setCurrentIndex(data.currentIndex)
                 .addAllServiceDefinitions(services)
                 .build()
         }

--- a/persistence/src/main/proto/persistent_service_data.proto
+++ b/persistence/src/main/proto/persistent_service_data.proto
@@ -5,7 +5,6 @@ option java_multiple_files = true;
 
 message PersistentServiceData {
   repeated PersistentServiceDefinition service_definitions = 1;
-  int32 current_index = 2;
 }
 
 message PersistentServiceDefinition {

--- a/persistence/src/test/java/com/github/oheger/wificontrol/persistence/source/CurrentServiceDataSourceImplTest.kt
+++ b/persistence/src/test/java/com/github/oheger/wificontrol/persistence/source/CurrentServiceDataSourceImplTest.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2023-2024 Oliver Heger.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.github.oheger.wificontrol.persistence.source
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.MutablePreferences
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+
+class CurrentServiceDataSourceImplTest : WordSpec({
+    beforeTest {
+        mockkStatic(DataStore<Preferences>::edit)
+    }
+
+    afterTest {
+        unmockkAll()
+        CurrentServiceDataSourceImpl.resetInvocationOnStartup()
+    }
+
+    "saveCurrentService" should {
+        "store the name of the current service" {
+            val preferences = mockk<MutablePreferences> {
+                every { set(CurrentServiceDataSourceImpl.CURRENT_SERVICE_NAME_KEY, any()) } just runs
+            }
+            val dataStore = mockDataStoreForEdit(preferences)
+
+            val dataSource = CurrentServiceDataSourceImpl(dataStore)
+            dataSource.saveCurrentService(SERVICE_NAME)
+
+            dataStore.executeEdit(preferences)
+            verify {
+                preferences[CurrentServiceDataSourceImpl.CURRENT_SERVICE_NAME_KEY] = SERVICE_NAME
+            }
+        }
+
+        "remove the name of the current service if it is null" {
+            val preferences = mockk<MutablePreferences> {
+                every { remove(CurrentServiceDataSourceImpl.CURRENT_SERVICE_NAME_KEY) } returns ""
+            }
+            val dataStore = mockDataStoreForEdit(preferences)
+
+            val dataSource = CurrentServiceDataSourceImpl(dataStore)
+            dataSource.saveCurrentService(null)
+
+            dataStore.executeEdit(preferences)
+            verify {
+                preferences.remove(CurrentServiceDataSourceImpl.CURRENT_SERVICE_NAME_KEY)
+            }
+        }
+    }
+
+    "loadCurrentServiceOnStartup" should {
+        "return the flow retrieved from DataStore on first invocation" {
+            val preferences = mockk<Preferences> {
+                every { get(CurrentServiceDataSourceImpl.CURRENT_SERVICE_NAME_KEY) } returns SERVICE_NAME
+            }
+            val dataStore = mockk<DataStore<Preferences>> {
+                every { data } returns flowOf(preferences)
+            }
+
+            val dataSource = CurrentServiceDataSourceImpl(dataStore)
+            val serviceName = dataSource.loadCurrentServiceOnStartup().first()
+
+            serviceName shouldBe SERVICE_NAME
+        }
+
+        "return an empty flow on succeeding invocations" {
+            val preferences = mockk<Preferences> {
+                every { get(CurrentServiceDataSourceImpl.CURRENT_SERVICE_NAME_KEY) } returns null
+            }
+            val dataStore = mockk<DataStore<Preferences>> {
+                every { data } returns flowOf(preferences)
+            }
+
+            val dataSource1 = CurrentServiceDataSourceImpl(dataStore)
+            dataSource1.loadCurrentServiceOnStartup().first().shouldBeNull()
+
+            val dataSource2 = CurrentServiceDataSourceImpl(dataStore)
+            val nextFlow = dataSource2.loadCurrentServiceOnStartup()
+            val values = nextFlow.toList()
+
+            values should beEmpty()
+            verify(exactly = 1) {
+                dataStore.data
+            }
+        }
+    }
+})
+
+/** The name of the current service used by tests. */
+private const val SERVICE_NAME = "theCurrentService"
+
+/**
+ * Create a mock for a [DataStore] that is prepared for a [DataStore.edit] operation.
+ */
+private fun mockDataStoreForEdit(preferences: MutablePreferences): DataStore<Preferences> =
+    mockk {
+        coEvery { edit(any()) } returns preferences
+    }
+
+/**
+ * Execute an edit operation on this [DataStore] mock providing the given [preferences] to the transform function.
+ */
+private suspend fun DataStore<Preferences>.executeEdit(preferences: MutablePreferences) {
+    val slot = slot<suspend (MutablePreferences) -> Unit>()
+    coVerify { edit(capture(slot)) }
+    slot.captured.invoke(preferences)
+}

--- a/persistence/src/test/java/com/github/oheger/wificontrol/persistence/source/PersistentServiceDataSerializerTest.kt
+++ b/persistence/src/test/java/com/github/oheger/wificontrol/persistence/source/PersistentServiceDataSerializerTest.kt
@@ -29,7 +29,6 @@ class PersistentServiceDataSerializerTest : StringSpec({
         val defaultServiceData = PersistentServiceDataSerializer.defaultValue
 
         defaultServiceData.serviceDefinitionsCount shouldBe 0
-        defaultServiceData.currentIndex shouldBe 0
     }
 
     "A round-trip with serialization and deserialization should work" {
@@ -49,7 +48,6 @@ class PersistentServiceDataSerializerTest : StringSpec({
             .build()
         val data = PersistentServiceData.newBuilder()
             .addAllServiceDefinitions(listOf(service1, service2))
-            .setCurrentIndex(1)
             .build()
 
         val bos = ByteArrayOutputStream()

--- a/persistence/src/test/java/com/github/oheger/wificontrol/persistence/source/ServicesDataSourceImplTest.kt
+++ b/persistence/src/test/java/com/github/oheger/wificontrol/persistence/source/ServicesDataSourceImplTest.kt
@@ -93,7 +93,6 @@ private val persistentService2 = PersistentServiceDefinition.newBuilder()
 /** A persistent service data instance used by tests. */
 private val persistentServiceData = PersistentServiceData.newBuilder()
     .addAllServiceDefinitions(listOf(persistentService1, persistentService2))
-    .setCurrentIndex(1)
     .build()
 
 /** A service from the domain layer corresponding to the first persistent test service. */
@@ -121,6 +120,5 @@ private val modelService2 = PersistentService(
 
 /** A service data instance from the domain layer corresponding to the persistent service data. */
 private val modelServiceData = ServiceData(
-    services = listOf(modelService1, modelService2),
-    currentIndex = 1
+    services = listOf(modelService1, modelService2)
 )

--- a/repository/src/main/java/com/github/oheger/wificontrol/repository/di/RepositoryModule.kt
+++ b/repository/src/main/java/com/github/oheger/wificontrol/repository/di/RepositoryModule.kt
@@ -18,9 +18,11 @@
  */
 package com.github.oheger.wificontrol.repository.di
 
+import com.github.oheger.wificontrol.domain.repo.CurrentServiceRepository
 import com.github.oheger.wificontrol.domain.repo.ServiceDataRepository
 import com.github.oheger.wificontrol.domain.repo.ServiceUriRepository
 import com.github.oheger.wificontrol.domain.repo.WiFiStateRepository
+import com.github.oheger.wificontrol.repository.impl.CurrentServiceRepositoryImpl
 import com.github.oheger.wificontrol.repository.impl.ServiceDataRepositoryImpl
 import com.github.oheger.wificontrol.repository.impl.ServiceUriRepositoryImpl
 import com.github.oheger.wificontrol.repository.impl.WiFiStateRepositoryImpl
@@ -38,6 +40,11 @@ import dagger.hilt.components.SingletonComponent
 abstract class RepositoryModule {
     @Binds
     abstract fun serviceDataRepository(serviceDataRepository: ServiceDataRepositoryImpl): ServiceDataRepository
+
+    @Binds
+    abstract fun currentServiceRepository(
+        currentServiceRepositoryImpl: CurrentServiceRepositoryImpl
+    ): CurrentServiceRepository
 
     @Binds
     abstract fun wiFiStateRepository(stateRepository: WiFiStateRepositoryImpl): WiFiStateRepository

--- a/repository/src/main/java/com/github/oheger/wificontrol/repository/ds/CurrentServiceDataSource.kt
+++ b/repository/src/main/java/com/github/oheger/wificontrol/repository/ds/CurrentServiceDataSource.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023-2024 Oliver Heger.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.github.oheger.wificontrol.repository.ds
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Definition of a data source interface for persisting the service that is currently controlled by the app. The
+ * data source is used by the corresponding repository implementation. As the main use case of this data source is to
+ * restore the last controlled service on startup of the app, the functions for loading and saving are a bit
+ * asymmetric: The load function only initially returns a persisted service name; when invoked later again, it yields
+ * an empty flow. The save function in contrast updates the service every time it is invoked.
+ */
+interface CurrentServiceDataSource {
+    /**
+     * Return a [Flow] with the name of the service to be controlled. This [Flow] only yields a result for the first
+     * invocation of the function. This is used by the application logic to trigger the navigation to the control UI
+     * if the service name is defined. The function can be called later again, but it then yields a [Flow] that does
+     * not emit any value; hence, no navigation is performed.
+     */
+    fun loadCurrentServiceOnStartup(): Flow<String?>
+
+    /**
+     * Persists the given [serviceName] of the currently controlled service. A value of *null* means that there is
+     * currently no service which is controlled; so no control UI can be restored.
+     */
+    suspend fun saveCurrentService(serviceName: String?)
+}

--- a/repository/src/main/java/com/github/oheger/wificontrol/repository/impl/CurrentServiceRepositoryImpl.kt
+++ b/repository/src/main/java/com/github/oheger/wificontrol/repository/impl/CurrentServiceRepositoryImpl.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023-2024 Oliver Heger.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.github.oheger.wificontrol.repository.impl
+
+import com.github.oheger.wificontrol.domain.model.CurrentService
+import com.github.oheger.wificontrol.domain.model.DefinedCurrentService
+import com.github.oheger.wificontrol.domain.model.UndefinedCurrentService
+import com.github.oheger.wificontrol.domain.repo.CurrentServiceRepository
+import com.github.oheger.wificontrol.repository.ds.CurrentServiceDataSource
+
+import javax.inject.Inject
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+
+/**
+ * An implementation of the [CurrentServiceRepository] interface that is based on a [CurrentServiceDataSource] for
+ * persisting the name of the currently controlled service.
+ */
+class CurrentServiceRepositoryImpl @Inject constructor(
+    /** The data source for loading and saving the current service. */
+    private val currentServiceDataSource: CurrentServiceDataSource
+) : CurrentServiceRepository {
+    override fun getCurrentService(): Flow<CurrentService> =
+        currentServiceDataSource.loadCurrentServiceOnStartup()
+            .map { serviceName ->
+                serviceName?.let(::DefinedCurrentService) ?: UndefinedCurrentService
+            }
+
+    override fun setCurrentService(currentService: CurrentService): Flow<CurrentService> = flow {
+        val serviceName = when (currentService) {
+            is DefinedCurrentService -> currentService.serviceName
+            is UndefinedCurrentService -> null
+        }
+
+        currentServiceDataSource.saveCurrentService(serviceName)
+        emit(Unit)
+    }.flatMapLatest {
+        getCurrentService()
+    }
+}

--- a/repository/src/test/java/com/github/oheger/wificontrol/repository/impl/CurrentServiceRepositoryImplTest.kt
+++ b/repository/src/test/java/com/github/oheger/wificontrol/repository/impl/CurrentServiceRepositoryImplTest.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2023-2024 Oliver Heger.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.github.oheger.wificontrol.repository.impl
+
+import com.github.oheger.wificontrol.domain.model.DefinedCurrentService
+import com.github.oheger.wificontrol.domain.model.UndefinedCurrentService
+import com.github.oheger.wificontrol.repository.ds.CurrentServiceDataSource
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+
+class CurrentServiceRepositoryImplTest : WordSpec({
+    "getCurrentService" should {
+        "return a flow with a defined service if a service name is available" {
+            val serviceName = "thePersistedCurrentService"
+            val serviceSource = mockk<CurrentServiceDataSource> {
+                every { loadCurrentServiceOnStartup() } returns flowOf(serviceName)
+            }
+
+            val repository = CurrentServiceRepositoryImpl(serviceSource)
+            val currentService = repository.getCurrentService().first()
+
+            currentService shouldBe DefinedCurrentService(serviceName)
+        }
+
+        "return a flow with an undefined service if a null service name is obtained from the data source" {
+            val serviceSource = mockk<CurrentServiceDataSource> {
+                every { loadCurrentServiceOnStartup() } returns flowOf(null)
+            }
+
+            val repository = CurrentServiceRepositoryImpl(serviceSource)
+            val currentService = repository.getCurrentService().first()
+
+            currentService shouldBe UndefinedCurrentService
+        }
+    }
+
+    "setCurrentService" should {
+        "persist a defined service" {
+            val currentService = DefinedCurrentService("serviceToPersist")
+            val persistedServiceName = "${currentService.serviceName}-andPersisted"
+            val serviceSource = mockk<CurrentServiceDataSource> {
+                coEvery { saveCurrentService(currentService.serviceName) } just runs
+                every { loadCurrentServiceOnStartup() } returns flowOf(persistedServiceName)
+            }
+
+            val repository = CurrentServiceRepositoryImpl(serviceSource)
+            val result = repository.setCurrentService(currentService).first()
+
+            result shouldBe DefinedCurrentService(persistedServiceName)
+            coVerify {
+                serviceSource.saveCurrentService(currentService.serviceName)
+            }
+        }
+
+        "persist an undefined service" {
+            val serviceSource = mockk<CurrentServiceDataSource> {
+                coEvery { saveCurrentService(null) } just runs
+                every { loadCurrentServiceOnStartup() } returns flowOf(null)
+            }
+
+            val repository = CurrentServiceRepositoryImpl(serviceSource)
+            val result = repository.setCurrentService(UndefinedCurrentService).first()
+
+            result shouldBe UndefinedCurrentService
+            coVerify {
+                serviceSource.saveCurrentService(null)
+            }
+        }
+    }
+})

--- a/repository/src/test/java/com/github/oheger/wificontrol/repository/impl/ServiceDataRepositoryImplTest.kt
+++ b/repository/src/test/java/com/github/oheger/wificontrol/repository/impl/ServiceDataRepositoryImplTest.kt
@@ -36,10 +36,7 @@ import kotlinx.coroutines.flow.flowOf
 class ServiceDataRepositoryImplTest : WordSpec({
     "getServiceData" should {
         "return a Flow with ServiceData objects from the data source" {
-            val serviceData = ServiceData(
-                services = listOf(mockk(), mockk()),
-                currentIndex = 1
-            )
+            val serviceData = ServiceData(services = listOf(mockk(), mockk()))
             val dataSource = mockk<ServicesDataSource> {
                 every { loadServiceData() } returns flowOf(serviceData)
             }


### PR DESCRIPTION
This PR adds the functionality that the app on startup switches to the control UI of the service that was active when the app was closed. If there is no such control UI, the app starts with the services overview screen.