### PR TITLE
Validation for the edit service form

### DIFF
--- a/app/src/main/java/com/github/oheger/wificontrol/svcui/ServiceDetailsUi.kt
+++ b/app/src/main/java/com/github/oheger/wificontrol/svcui/ServiceDetailsUi.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Button
 import androidx.compose.material.Icon
@@ -43,6 +44,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -263,6 +265,7 @@ private fun EditServiceDetails(
     ) {
         EditServiceProperty(
             labelRes = R.string.svc_lab_name,
+            keyboardOptions = KeyboardOptions.Default,
             value = editModel.serviceName,
             updateValue = { editModel.serviceName = it },
             errorRes = R.string.svc_name_invalid.takeUnless { editModel.serviceNameValid },
@@ -271,6 +274,7 @@ private fun EditServiceDetails(
         )
         EditServiceProperty(
             labelRes = R.string.svc_lab_multicast,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
             value = editModel.multicastAddress,
             updateValue = { editModel.multicastAddress = it },
             errorRes = R.string.svc_address_invalid.takeUnless { editModel.multicastAddressValid },
@@ -279,6 +283,7 @@ private fun EditServiceDetails(
         )
         EditServiceProperty(
             labelRes = R.string.svc_lab_port,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
             value = editModel.port,
             updateValue = { editModel.port = it },
             errorRes = R.string.svc_port_invalid.takeUnless { editModel.portValid },
@@ -287,6 +292,7 @@ private fun EditServiceDetails(
         )
         EditServiceProperty(
             labelRes = R.string.svc_lab_code,
+            keyboardOptions = KeyboardOptions.Default,
             value = editModel.code,
             updateValue = { editModel.code = it },
             errorRes = R.string.svc_code_invalid.takeUnless { editModel.codeValid },
@@ -341,12 +347,14 @@ private fun ServiceProperty(labelRes: Int, value: String, tag: String, modifier:
 /**
  * Generate the UI to edit a single property of a service. This contains a label with the given
  * [resource ID][labelRes], and a text field displaying the given [value] and using the [updateValue] function to
- * propagate changes. If the user input is invalid, a resource ID with a corresponding error message is provided in
- * [errorRes]; then display this message. Assign the given [tag] to the edit text field.
+ * propagate changes. The input can be edited with a keyboard corresponding to the provided [keyboardOptions]. If the
+ * user input is invalid, a resource ID with a corresponding error message is provided in [errorRes]; then display this
+ * message. Assign the given [tag] to the edit text field.
  */
 @Composable
 private fun EditServiceProperty(
     labelRes: Int,
+    keyboardOptions: KeyboardOptions,
     value: String,
     updateValue: (String) -> Unit,
     errorRes: Int?,
@@ -362,6 +370,7 @@ private fun EditServiceProperty(
         TextField(
             value = value,
             onValueChange = updateValue,
+            keyboardOptions = keyboardOptions,
             modifier = modifier
                 .testTag(tag)
                 .padding(start = PROPERTY_INDENT.dp)

--- a/app/src/main/java/com/github/oheger/wificontrol/svcui/ServiceDetailsUi.kt
+++ b/app/src/main/java/com/github/oheger/wificontrol/svcui/ServiceDetailsUi.kt
@@ -68,12 +68,15 @@ import com.github.oheger.wificontrol.domain.model.ServiceData
 import com.github.oheger.wificontrol.domain.model.ServiceDefinition
 import com.github.oheger.wificontrol.ui.theme.WifiControlTheme
 
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 internal const val TAG_SHOW_NAME = "svcShowName"
 internal const val TAG_SHOW_MULTICAST = "svcShowMulticast"
 internal const val TAG_SHOW_PORT = "svcShowPort"
 internal const val TAG_SHOW_CODE = "svcShowCode"
+internal const val TAG_SHOW_LOOKUP_TIMEOUT = "svcShowLookupTimeout"
+internal const val TAG_SHOW_REQUEST_INTERVAL = "svcShowRequestInterval"
 
 internal const val TAG_EDIT_NAME = "svcEditName"
 internal const val TAG_EDIT_MULTICAST = "svcEditMulticast"
@@ -265,6 +268,20 @@ private fun ViewServiceDetails(service: PersistentService, modifier: Modifier) {
             tag = TAG_SHOW_CODE,
             modifier = modifier
         )
+        ServiceDurationProperty(
+            labelRes = R.string.svc_lab_lookup_timeout,
+            value = service.lookupTimeout?.inWholeSeconds,
+            unitRes = R.string.svc_unit_sec,
+            tag = TAG_SHOW_LOOKUP_TIMEOUT,
+            modifier = modifier
+        )
+        ServiceDurationProperty(
+            labelRes = R.string.svc_lab_request_interval,
+            value = service.sendRequestInterval?.inWholeMilliseconds,
+            unitRes = R.string.svc_unit_ms,
+            tag = TAG_SHOW_REQUEST_INTERVAL,
+            modifier = modifier
+        )
     }
 }
 
@@ -358,9 +375,11 @@ private fun EditServiceDetails(
 private fun EditFormTabTitle(labelRes: Int, invalidTag: String?, modifier: Modifier) {
     Row(verticalAlignment = Alignment.CenterVertically) {
         invalidTag?.let {
-            Icon(Icons.Filled.Warning, contentDescription = null, modifier = modifier
-                .testTag(it)
-                .width(10.dp))
+            Icon(
+                Icons.Filled.Warning, contentDescription = null, modifier = modifier
+                    .testTag(it)
+                    .width(10.dp)
+            )
             Spacer(modifier = modifier.width(3.dp))
         }
         Text(stringResource(labelRes))
@@ -469,6 +488,33 @@ private fun ServiceProperty(labelRes: Int, value: String, tag: String, modifier:
                 .testTag(tag)
                 .padding(start = PROPERTY_INDENT.dp)
         )
+    }
+}
+
+/**
+ * Generate the UI to show an optional service property for a duration with the given [resource ID][labelRes], the
+ * given [value], and the resource ID for the [unit][unitRes]. Assign the given [tag] to the text with the value.
+ */
+@Composable
+private fun ServiceDurationProperty(labelRes: Int, value: Long?, unitRes: Int, tag: String, modifier: Modifier) {
+    value?.let { durationValue ->
+        Column(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(top = 15.dp)
+        ) {
+            PropertyLabel(labelRes = labelRes, modifier = modifier)
+            Row(modifier = modifier.padding(start = PROPERTY_INDENT.dp)) {
+                Text(
+                    text = durationValue.toString(),
+                    modifier = modifier.testTag(tag)
+                )
+                Text(
+                    text = stringResource(unitRes),
+                    modifier = modifier.padding(start = 4.dp)
+                )
+            }
+        }
     }
 }
 
@@ -598,7 +644,7 @@ fun ViewServiceDetailsPreview() {
             requestCode = "Lookup_audio_service"
         ),
         lookupTimeout = null,
-        sendRequestInterval = null
+        sendRequestInterval = 50.milliseconds
     )
     val serviceData = ServiceData(emptyList())
     val editModel = ServiceEditModel(service)

--- a/app/src/main/java/com/github/oheger/wificontrol/svcui/ServiceDetailsViewModel.kt
+++ b/app/src/main/java/com/github/oheger/wificontrol/svcui/ServiceDetailsViewModel.kt
@@ -97,6 +97,9 @@ class ServiceDetailsViewModel @Inject constructor(
             state.copy(saveError = error)
         }
 
+    /** A special model object for editing the current service. */
+    internal lateinit var editModel: ServiceEditModel
+
     /**
      * Load the current state of the service details UI for the service specified in the given [parameters]. This will
      * trigger [uiStateFlow] when the data is available.
@@ -106,7 +109,10 @@ class ServiceDetailsViewModel @Inject constructor(
             loadServiceUseCase.execute(LoadServiceUseCase.Input(parameters.serviceIndex))
                 .mapResultFlow { result ->
                     ServiceDetailsState(result.serviceData, parameters.serviceIndex, result.service, editMode = false)
-                }.collect { state -> mutableUiStateFlow.value = state }
+                }.collect { state ->
+                    (state as? ServicesUiStateLoaded)?.let { editModel = ServiceEditModel(it.data.service) }
+                    mutableUiStateFlow.value = state
+                }
         }
 
         return UndefinedCurrentService

--- a/app/src/main/java/com/github/oheger/wificontrol/svcui/ServiceEditModel.kt
+++ b/app/src/main/java/com/github/oheger/wificontrol/svcui/ServiceEditModel.kt
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2023-2024 Oliver Heger.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.github.oheger.wificontrol.svcui
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+
+import com.github.oheger.wificontrol.domain.model.PersistentService
+import com.github.oheger.wificontrol.domain.model.ServiceDefinition
+
+/**
+ * A helper class that stores information about the properties of a service that is currently edited.
+ *
+ * The goal of this class is to provide sufficient information for an editor UI. This includes all the properties of
+ * a service, but also information if the current values are valid or if there are validation failures. For a new
+ * service, the properties are initially invalid (since they are empty). However, the UI should not display lots of
+ * errors initially. Therefore, a property is considered invalid only after it has been changed or after a full
+ * validation.
+ */
+internal class ServiceEditModel(
+    /** The service to be edited using this model. */
+    service: PersistentService
+) {
+    companion object {
+        /** Regular expression to validate an IP address. */
+        private val regIpAddress = Regex("""(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})""")
+
+        /**
+         * Return a flag whether the given mandatory [string][s] is valid.
+         */
+        internal fun validateRequiredString(s: String): Boolean =
+            s.isNotBlank() && s == s.trim()
+
+        /**
+         * Return a flag whether the given [address] is a valid multicast IP address.
+         */
+        internal fun validateMulticastAddress(address: String): Boolean =
+            regIpAddress.matchEntire(address)?.let { result ->
+                result.groups.drop(1).all { component ->
+                    val componentInt = component?.value?.toInt() ?: -1
+                    componentInt in 0..255
+                }
+            } == true
+
+        /**
+         * Return a flag whether the given [port] is a valid port number.
+         */
+        internal fun validatePort(port: String): Boolean =
+            runCatching { port.toInt() in 0..65535 }.getOrDefault(false)
+    }
+
+    /** Stores the name of the service. */
+    private var serviceNameField by mutableStateOf(service.serviceDefinition.name)
+
+    /** Stores the result of the service name validation. */
+    private var serviceNameValidationResult by mutableStateOf(validateRequiredString(serviceNameField))
+
+    /** Stores a flag whether the service name property has already been edited. */
+    private var serviceNameEdited by mutableStateOf(false)
+
+    /** The name of the edited service. */
+    var serviceName: String
+        get() = serviceNameField
+        set(value) {
+            serviceNameField = value
+            serviceNameEdited = true
+            serviceNameValidationResult = validateRequiredString(value)
+        }
+
+    /** Flag whether the service name is considered valid. */
+    val serviceNameValid: Boolean
+        get() = serviceNameValidationResult || !serviceNameEdited
+
+    /** Stores the multicast lookup address of the service. */
+    private var multicastAddressField by mutableStateOf(service.serviceDefinition.multicastAddress)
+
+    /** Stores the result of the multicast address validation. */
+    private var multicastAddressValidationResult by mutableStateOf(validateMulticastAddress(multicastAddressField))
+
+    /** Stores a flag whether the multicast address property has already been edited. */
+    private var multicastAddressEdited by mutableStateOf(false)
+
+    /** Property for the multicast lookup address of the service. */
+    var multicastAddress: String
+        get() = multicastAddressField
+        set(value) {
+            multicastAddressField = value
+            multicastAddressEdited = true
+            multicastAddressValidationResult = validateMulticastAddress(value)
+        }
+
+    /** Flag whether the multicast address is considered valid. */
+    val multicastAddressValid: Boolean
+        get() = multicastAddressValidationResult || !multicastAddressEdited
+
+    /** Stores the port of the service. */
+    private var portField by mutableStateOf(service.serviceDefinition.port.toString())
+
+    /** Stores the result of the port validation. */
+    private var portValidationResult by mutableStateOf(validatePort(portField))
+
+    /** Stores a flag whether the port property has already been edited. */
+    private var portEdited by mutableStateOf(false)
+
+    /** Property for the port of the service. */
+    var port: String
+        get() = portField
+        set(value) {
+            portField = value
+            portEdited = true
+            portValidationResult = validatePort(value)
+        }
+
+    /** Flag whether the port is considered valid. */
+    val portValid: Boolean
+        get() = portValidationResult || !portEdited
+
+    /** Stores the request code for the service. */
+    private var codeField by mutableStateOf(service.serviceDefinition.requestCode)
+
+    /** Stores the result of the request code validation. */
+    private var codeValidationResult by mutableStateOf(validateRequiredString(codeField))
+
+    /** Stores a flag whether the request code property has already been edited. */
+    private var codeEdited by mutableStateOf(false)
+
+    /** Property for the request code of the service. */
+    var code: String
+        get() = codeField
+        set(value) {
+            codeField = value
+            codeEdited = true
+            codeValidationResult = validateRequiredString(value)
+        }
+
+    /** Flag whether the code is considered valid. */
+    val codeValid: Boolean
+        get() = codeValidationResult || !codeEdited
+
+    /**
+     * Perform a full validation of all edit fields and return a flag with the result. After calling this function,
+     * all fields are marked as edited, so that the _Valid_ properties are correctly initialized. Only if this
+     * function returns *true*, the edit operation can be successfully completed. If the result is *false*, the UI
+     * can update itself and mark the invalid fields accordingly.
+     */
+    fun validate(): Boolean {
+        serviceNameEdited = true
+        multicastAddressEdited = true
+        portEdited = true
+        codeEdited = true
+
+        return serviceNameValidationResult && multicastAddressValidationResult && portValidationResult &&
+                codeValidationResult
+    }
+
+    /**
+     * Return a [PersistentService] instance with properties that correspond to the current values in the edit fields.
+     * This function can be called only after [validate] has returned *true*.
+     */
+    fun editedService(): PersistentService =
+        PersistentService(
+            serviceDefinition = ServiceDefinition(
+                name = serviceName,
+                multicastAddress = multicastAddress,
+                port = port.toInt(),
+                requestCode = code
+            ),
+            lookupTimeout = null,
+            sendRequestInterval = null
+        )
+}

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -31,4 +31,8 @@
     <string name="svc_del_conf_text">Wollen Sie den Dienst \'%1s\' wirklich löschen?</string>
     <string name="svc_del_conf_btn_delete">Löschen</string>
     <string name="svc_del_conf_btn_cancel">Abbrechen</string>
+    <string name="svc_name_invalid">Der Name des Dienstes muss ein nicht leerer Text ohne führende und schließende Leerzeichen sein.</string>
+    <string name="svc_address_invalid">Dies muss eine gültige IP-Adresse sein, wie z.B. 231.1.120.17.</string>
+    <string name="svc_port_invalid">Dies muss eine gültige Port-Nummer im Bereich von 0 bis 65535 sein.</string>
+    <string name="svc_code_invalid">Der Request Code muss ein nicht leerer Text ohne führende und schließende Leerzeichen sein.</string>
 </resources>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -42,4 +42,6 @@
     <string name="svc_request_interval_invalid">Geben Sie bitter eine Zahl größer 0 an für das Intervall in Millisekunden.</string>
     <string name="svc_tab_properties">Eigenschaften</string>
     <string name="svc_tab_extended">Erweitert</string>
+    <string name="svc_unit_sec">sek</string>
+    <string name="svc_unit_ms">ms</string>
 </resources>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -35,4 +35,11 @@
     <string name="svc_address_invalid">Dies muss eine gültige IP-Adresse sein, wie z.B. 231.1.120.17.</string>
     <string name="svc_port_invalid">Dies muss eine gültige Port-Nummer im Bereich von 0 bis 65535 sein.</string>
     <string name="svc_code_invalid">Der Request Code muss ein nicht leerer Text ohne führende und schließende Leerzeichen sein.</string>
+    <string name="svc_use_default">Vorgabe verwenden</string>
+    <string name="svc_lab_lookup_timeout">Timeout für Suche des Diensts (sek)</string>
+    <string name="svc_lab_request_interval">Intervall für Suchanfragen (ms)</string>
+    <string name="svc_lookup_timeout_invalid">Geben Sie bitte eine Zahl größer 0 an für den Timeout in Sekunden.</string>
+    <string name="svc_request_interval_invalid">Geben Sie bitter eine Zahl größer 0 an für das Intervall in Millisekunden.</string>
+    <string name="svc_tab_properties">Eigenschaften</string>
+    <string name="svc_tab_extended">Erweitert</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,4 +43,6 @@
     <string name="svc_request_interval_invalid">Please enter a number greater than 0 for the interval in milliseconds.</string>
     <string name="svc_tab_properties">Properties</string>
     <string name="svc_tab_extended">Extended</string>
+    <string name="svc_unit_sec">sec</string>
+    <string name="svc_unit_ms">ms</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,4 +32,8 @@
     <string name="svc_del_conf_text">Do you really want to delete the service \'%1s\'?</string>
     <string name="svc_del_conf_btn_delete">Delete</string>
     <string name="svc_del_conf_btn_cancel">Cancel</string>
+    <string name="svc_name_invalid">The service name must be a non-empty string without leading or trailing whitespace.</string>
+    <string name="svc_address_invalid">This must be a valid IP address, e.g. 231.1.120.17.</string>
+    <string name="svc_port_invalid">This must be a valid port number in the range of 0 to 65535.</string>
+    <string name="svc_code_invalid">The request code must be a non-empty string without leading or trailing whitespace.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,4 +36,11 @@
     <string name="svc_address_invalid">This must be a valid IP address, e.g. 231.1.120.17.</string>
     <string name="svc_port_invalid">This must be a valid port number in the range of 0 to 65535.</string>
     <string name="svc_code_invalid">The request code must be a non-empty string without leading or trailing whitespace.</string>
+    <string name="svc_use_default">Use default</string>
+    <string name="svc_lab_lookup_timeout">Service discovery timeout (s)</string>
+    <string name="svc_lab_request_interval">Interval for search requests (ms)</string>
+    <string name="svc_lookup_timeout_invalid">Please enter a number greater than 0 for the timeout in seconds.</string>
+    <string name="svc_request_interval_invalid">Please enter a number greater than 0 for the interval in milliseconds.</string>
+    <string name="svc_tab_properties">Properties</string>
+    <string name="svc_tab_extended">Extended</string>
 </resources>

--- a/app/src/test/java/com/github/oheger/wificontrol/svcui/CreateServiceUiTest.kt
+++ b/app/src/test/java/com/github/oheger/wificontrol/svcui/CreateServiceUiTest.kt
@@ -19,15 +19,17 @@
 package com.github.oheger.wificontrol.svcui
 
 import android.content.Context
+
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotSelected
 import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.assertIsSelected
-
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.navigation.NavController
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -122,6 +124,8 @@ class CreateServiceUiTest {
             composeTestRule.onNodeWithTag(tag).assertDoesNotExist()
             composeTestRule.onNodeWithTag(useDefaultTag(tag)).assertDoesNotExist()
         }
+        composeTestRule.onNodeWithTag(TAG_TAB_PROPERTIES_INVALID).assertDoesNotExist()
+        composeTestRule.onNodeWithTag(TAG_TAB_EXTENDED_INVALID).assertDoesNotExist()
     }
 
     @Test
@@ -226,6 +230,8 @@ class CreateServiceUiTest {
         composeTestRule.enterServiceProperties(errorService, save = false)
 
         composeTestRule.assertAllValidationErrors()
+        composeTestRule.onNodeWithTag(TAG_TAB_PROPERTIES).performScrollTo()
+        composeTestRule.onNodeWithTag(TAG_TAB_PROPERTIES_INVALID, useUnmergedTree = true).assertIsDisplayed()
     }
 
     @Test
@@ -244,6 +250,8 @@ class CreateServiceUiTest {
         listOf(TAG_EDIT_LOOKUP_TIMEOUT, TAG_EDIT_REQUEST_INTERVAL).forAll { tag ->
             composeTestRule.onNodeWithTag(errorTag(tag)).assertExists()
         }
+        composeTestRule.onNodeWithTag(TAG_TAB_EXTENDED).performScrollTo()
+        composeTestRule.onNodeWithTag(TAG_TAB_EXTENDED_INVALID, useUnmergedTree = true).assertIsDisplayed()
     }
 
     @Test

--- a/app/src/test/java/com/github/oheger/wificontrol/svcui/EditServiceTestHelper.kt
+++ b/app/src/test/java/com/github/oheger/wificontrol/svcui/EditServiceTestHelper.kt
@@ -28,6 +28,8 @@ import com.github.oheger.wificontrol.setText
 
 import io.kotest.inspectors.forAll
 
+import kotlin.time.Duration.Companion.seconds
+
 /**
  * A list with tags representing the UI elements to display invalid input for the several properties.
  */
@@ -46,6 +48,15 @@ internal fun ComposeTestRule.enterServiceProperties(service: PersistentService, 
     if (save) {
         saveForm()
     }
+}
+
+/**
+ * Populate the edit field for the property identified by the given [tag] that supports a default value with the given
+ * [value].
+ */
+internal fun ComposeTestRule.enterNonDefaultProperty(tag: String, value: String) {
+    onNodeWithTag(useDefaultTag(tag)).performSafeClick()
+    onNodeWithTag(tag).setText(value)
 }
 
 /**
@@ -84,6 +95,6 @@ internal val errorServiceDefinition = ServiceDefinition(
 /** A service that contains only invalid properties. */
 internal val errorService = PersistentService(
     serviceDefinition = errorServiceDefinition,
-    lookupTimeout = null,
-    sendRequestInterval = null
+    lookupTimeout = 0.seconds,
+    sendRequestInterval = 0.seconds
 )

--- a/app/src/test/java/com/github/oheger/wificontrol/svcui/EditServiceTestHelper.kt
+++ b/app/src/test/java/com/github/oheger/wificontrol/svcui/EditServiceTestHelper.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2023-2024 Oliver Heger.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.github.oheger.wificontrol.svcui
+
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.onNodeWithTag
+
+import com.github.oheger.wificontrol.domain.model.PersistentService
+import com.github.oheger.wificontrol.domain.model.ServiceDefinition
+import com.github.oheger.wificontrol.performSafeClick
+import com.github.oheger.wificontrol.setText
+
+import io.kotest.inspectors.forAll
+
+/**
+ * A list with tags representing the UI elements to display invalid input for the several properties.
+ */
+internal val errorTags = listOf(TAG_EDIT_NAME, TAG_EDIT_MULTICAST, TAG_EDIT_PORT, TAG_EDIT_CODE)
+    .map(::errorTag)
+
+/**
+ * Populate the edit fields of the form with the properties of the given [service]. If the [save] flag is *true*,
+ * also simulate a click on the save button.
+ */
+internal fun ComposeTestRule.enterServiceProperties(service: PersistentService, save: Boolean = true) {
+    onNodeWithTag(TAG_EDIT_NAME).setText(service.serviceDefinition.name)
+    onNodeWithTag(TAG_EDIT_MULTICAST).setText(service.serviceDefinition.multicastAddress)
+    onNodeWithTag(TAG_EDIT_PORT).setText(service.serviceDefinition.port.toString())
+    onNodeWithTag(TAG_EDIT_CODE).setText(service.serviceDefinition.requestCode)
+    if (save) {
+        saveForm()
+    }
+}
+
+/**
+ * Click the save button of the edit form, so that user input is evaluated.
+ */
+internal fun ComposeTestRule.saveForm() {
+    onNodeWithTag(TAG_BTN_EDIT_SAVE).performSafeClick()
+}
+
+/**
+ * Check that no UI element reporting an invalid input is currently displayed.
+ */
+internal fun ComposeTestRule.assertNoValidationErrors() {
+    errorTags.forAll { tag ->
+        onNodeWithTag(tag).assertDoesNotExist()
+    }
+}
+
+/**
+ * Check that all UI elements reporting invalid input are currently displayed.
+ */
+internal fun ComposeTestRule.assertAllValidationErrors() {
+    errorTags.forAll { tag ->
+        onNodeWithTag(tag).assertExists()
+    }
+}
+
+/** A service definition that contains only invalid properties. This is used to test input validation. */
+internal val errorServiceDefinition = ServiceDefinition(
+    name = " ",
+    multicastAddress = "not an IP address",
+    port = 70000,
+    requestCode = " "
+)
+
+/** A service that contains only invalid properties. */
+internal val errorService = PersistentService(
+    serviceDefinition = errorServiceDefinition,
+    lookupTimeout = null,
+    sendRequestInterval = null
+)

--- a/app/src/test/java/com/github/oheger/wificontrol/svcui/ServiceDetailsUiTest.kt
+++ b/app/src/test/java/com/github/oheger/wificontrol/svcui/ServiceDetailsUiTest.kt
@@ -19,6 +19,7 @@
 package com.github.oheger.wificontrol.svcui
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsOff
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -50,6 +51,7 @@ import io.mockk.verify
 
 import java.util.concurrent.atomic.AtomicInteger
 
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -182,6 +184,22 @@ class ServiceDetailsUiTest {
         ).forAll {
             composeTestRule.onNodeWithTag(it).assertDoesNotExist()
         }
+    }
+
+    @Test
+    fun `Extended properties with non-default values are correctly initialized in edit mode`() = runTest {
+        val testService = service.copy(lookupTimeout = 88.seconds, sendRequestInterval = 44.milliseconds)
+        initService(testService)
+
+        composeTestRule.onNodeWithTag(TAG_BTN_EDIT_SERVICE).performClick()
+        composeTestRule.onNodeWithTag(TAG_TAB_EXTENDED).performClick()
+
+        composeTestRule.onNodeWithTag(useDefaultTag(TAG_EDIT_LOOKUP_TIMEOUT)).assertIsOff()
+        composeTestRule.onNodeWithTag(TAG_EDIT_LOOKUP_TIMEOUT)
+            .assertTextEquals(testService.lookupTimeout!!.inWholeSeconds.toString())
+        composeTestRule.onNodeWithTag(useDefaultTag(TAG_EDIT_REQUEST_INTERVAL)).assertIsOff()
+        composeTestRule.onNodeWithTag(TAG_EDIT_REQUEST_INTERVAL)
+            .assertTextEquals(testService.sendRequestInterval!!.inWholeMilliseconds.toString())
     }
 
     @Test

--- a/app/src/test/java/com/github/oheger/wificontrol/svcui/ServiceDetailsUiTest.kt
+++ b/app/src/test/java/com/github/oheger/wificontrol/svcui/ServiceDetailsUiTest.kt
@@ -170,6 +170,7 @@ class ServiceDetailsUiTest {
         composeTestRule.onNodeWithTag(TAG_EDIT_MULTICAST).assertTextEquals(service.serviceDefinition.multicastAddress)
         composeTestRule.onNodeWithTag(TAG_EDIT_PORT).assertTextEquals(service.serviceDefinition.port.toString())
         composeTestRule.onNodeWithTag(TAG_EDIT_CODE).assertTextEquals(service.serviceDefinition.requestCode)
+        composeTestRule.assertNoValidationErrors()
 
         listOf(
             TAG_SHOW_NAME,
@@ -213,11 +214,7 @@ class ServiceDetailsUiTest {
         )
 
         composeTestRule.onNodeWithTag(TAG_BTN_EDIT_SERVICE).performClick()
-        composeTestRule.onNodeWithTag(TAG_EDIT_NAME).setText(editedService.serviceDefinition.name)
-        composeTestRule.onNodeWithTag(TAG_EDIT_MULTICAST).setText(editedService.serviceDefinition.multicastAddress)
-        composeTestRule.onNodeWithTag(TAG_EDIT_PORT).setText(editedService.serviceDefinition.port.toString())
-        composeTestRule.onNodeWithTag(TAG_EDIT_CODE).setText(editedService.serviceDefinition.requestCode)
-        composeTestRule.onNodeWithTag(TAG_BTN_EDIT_SAVE).performSafeClick()
+        composeTestRule.enterServiceProperties(editedService)
 
         val expectedInput = StoreServiceUseCase.Input(
             data = loadOutput.serviceData,
@@ -228,6 +225,16 @@ class ServiceDetailsUiTest {
             storeUseCase.execute(expectedInput)
             navController.navigate(Navigation.ServicesRoute.route)
         }
+    }
+
+    @Test
+    fun `Clicking the save button performs a validation`() = runTest {
+        initService(service)
+        composeTestRule.onNodeWithTag(TAG_BTN_EDIT_SERVICE).performClick()
+
+        composeTestRule.enterServiceProperties(errorService)
+
+        composeTestRule.assertAllValidationErrors()
     }
 
     @Test

--- a/app/src/test/java/com/github/oheger/wificontrol/svcui/ServiceDetailsUiTest.kt
+++ b/app/src/test/java/com/github/oheger/wificontrol/svcui/ServiceDetailsUiTest.kt
@@ -156,9 +156,31 @@ class ServiceDetailsUiTest {
         composeTestRule.onNodeWithTag(TAG_SHOW_PORT).assertTextEquals(service.serviceDefinition.port.toString())
         composeTestRule.onNodeWithTag(TAG_SHOW_CODE).assertTextEquals(service.serviceDefinition.requestCode)
 
-        listOf(TAG_EDIT_NAME, TAG_EDIT_MULTICAST, TAG_EDIT_PORT, TAG_EDIT_CODE).forAll {
+        listOf(
+            TAG_EDIT_NAME,
+            TAG_EDIT_MULTICAST,
+            TAG_EDIT_PORT,
+            TAG_EDIT_CODE,
+            TAG_SHOW_LOOKUP_TIMEOUT,
+            TAG_SHOW_REQUEST_INTERVAL
+        ).forAll {
             composeTestRule.onNodeWithTag(it).assertDoesNotExist()
         }
+    }
+
+    @Test
+    fun `Extended service properties are shown if they are defined`() = runTest {
+        val lookupTimeoutSec = 77
+        val requestIntervalMs = 99
+        val testService = service.copy(
+            lookupTimeout = lookupTimeoutSec.seconds,
+            sendRequestInterval = requestIntervalMs.milliseconds
+        )
+        initService(testService)
+
+        composeTestRule.onNodeWithTag(TAG_SVC_TITLE).assertTextEquals(service.serviceDefinition.name)
+        composeTestRule.onNodeWithTag(TAG_SHOW_LOOKUP_TIMEOUT).assertTextEquals(lookupTimeoutSec.toString())
+        composeTestRule.onNodeWithTag(TAG_SHOW_REQUEST_INTERVAL).assertTextEquals(requestIntervalMs.toString())
     }
 
     @Test

--- a/app/src/test/java/com/github/oheger/wificontrol/svcui/ServiceEditModelTest.kt
+++ b/app/src/test/java/com/github/oheger/wificontrol/svcui/ServiceEditModelTest.kt
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2023-2024 Oliver Heger.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.github.oheger.wificontrol.svcui
+
+import com.github.oheger.wificontrol.domain.model.PersistentService
+import com.github.oheger.wificontrol.domain.model.ServiceDefinition
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+class ServiceEditModelTest : WordSpec({
+    "service name" should {
+        "be correctly initialized" {
+            val model = ServiceEditModel(service)
+
+            model.serviceName shouldBe serviceDefinition.name
+            model.serviceNameValid shouldBe true
+        }
+
+        "be correctly validated" {
+            val model = ServiceEditModel(service)
+
+            model.serviceName = " "
+            model.serviceNameValid shouldBe false
+        }
+
+        "not be marked as invalid initially" {
+            val invalidNameDefinition = serviceDefinition.copy(name = "")
+            val invalidService = service.copy(serviceDefinition = invalidNameDefinition)
+
+            val model = ServiceEditModel(invalidService)
+
+            model.serviceNameValid shouldBe true
+        }
+
+        "be handled correctly by validate" {
+            val invalidNameDefinition = serviceDefinition.copy(name = "")
+            val invalidService = service.copy(serviceDefinition = invalidNameDefinition)
+
+            val model = ServiceEditModel(invalidService)
+            model.validate() shouldBe false
+
+            model.serviceNameValid shouldBe false
+        }
+    }
+
+    "validateRequiredString" should {
+        "return false for a string with trailing whitespace" {
+            ServiceEditModel.validateRequiredString("TestService ") shouldBe false
+        }
+
+        "return false for a string with leading whitespace" {
+            ServiceEditModel.validateRequiredString(" TestService") shouldBe false
+        }
+    }
+
+    "multicast address" should {
+        "be correctly initialized" {
+            val model = ServiceEditModel(service)
+
+            model.multicastAddress shouldBe serviceDefinition.multicastAddress
+            model.multicastAddressValid shouldBe true
+        }
+
+        "be correctly validated" {
+            val model = ServiceEditModel(service)
+
+            model.multicastAddress = "x"
+            model.multicastAddressValid shouldBe false
+        }
+
+        "not be marked as invalid initially" {
+            val invalidAddressDefinition = serviceDefinition.copy(multicastAddress = "")
+            val invalidService = service.copy(serviceDefinition = invalidAddressDefinition)
+
+            val model = ServiceEditModel(invalidService)
+
+            model.multicastAddressValid shouldBe true
+        }
+
+        "be handled correctly by validate" {
+            val invalidAddressDefinition = serviceDefinition.copy(multicastAddress = "")
+            val invalidService = service.copy(serviceDefinition = invalidAddressDefinition)
+
+            val model = ServiceEditModel(invalidService)
+            model.validate() shouldBe false
+
+            model.multicastAddressValid shouldBe false
+        }
+    }
+
+    "validateMulticastAddress" should {
+        "return true for a valid IP address" {
+            ServiceEditModel.validateMulticastAddress("231.10.0.7") shouldBe true
+        }
+
+        "return false if a component is not a number" {
+            ServiceEditModel.validateMulticastAddress("1.2.3.a") shouldBe false
+        }
+
+        "return false if a component is out of range" {
+            ServiceEditModel.validateMulticastAddress("1.2.256.128") shouldBe false
+        }
+
+        "return false if a component is missing" {
+            ServiceEditModel.validateMulticastAddress("231.0.1") shouldBe false
+        }
+
+        "return false if there is a superfluous component" {
+            ServiceEditModel.validateMulticastAddress("231.0.1.2.3") shouldBe false
+        }
+    }
+
+    "port" should {
+        "be correctly initialized" {
+            val model = ServiceEditModel(service)
+
+            model.port shouldBe serviceDefinition.port.toString()
+            model.portValid shouldBe true
+        }
+
+        "be correctly validated" {
+            val model = ServiceEditModel(service)
+
+            model.port = "x"
+            model.portValid shouldBe false
+        }
+
+        "not be marked as invalid initially" {
+            val invalidPortDefinition = serviceDefinition.copy(port = -1)
+            val invalidService = service.copy(serviceDefinition = invalidPortDefinition)
+
+            val model = ServiceEditModel(invalidService)
+
+            model.portValid shouldBe true
+        }
+
+        "be handled correctly by validate" {
+            val invalidPortDefinition = serviceDefinition.copy(port = -1)
+            val invalidService = service.copy(serviceDefinition = invalidPortDefinition)
+
+            val model = ServiceEditModel(invalidService)
+            model.validate() shouldBe false
+
+            model.portValid shouldBe false
+        }
+    }
+
+    "validatePort" should {
+        "return false for a negative value" {
+            ServiceEditModel.validatePort("-1") shouldBe false
+        }
+
+        "return false for a value too big" {
+            ServiceEditModel.validatePort("65536") shouldBe false
+        }
+
+        "return false for a non-numeric value" {
+            ServiceEditModel.validatePort("notAPortNumber") shouldBe false
+        }
+    }
+
+    "code" should {
+        "be correctly initialized" {
+            val model = ServiceEditModel(service)
+
+            model.code shouldBe serviceDefinition.requestCode
+            model.codeValid shouldBe true
+        }
+
+        "be correctly validated" {
+            val model = ServiceEditModel(service)
+
+            model.code = ""
+            model.codeValid shouldBe false
+        }
+
+        "not be marked as invalid initially" {
+            val invalidCodeDefinition = serviceDefinition.copy(requestCode = "")
+            val invalidService = service.copy(serviceDefinition = invalidCodeDefinition)
+
+            val model = ServiceEditModel(invalidService)
+
+            model.codeValid shouldBe true
+        }
+
+        "be handled correctly by validate" {
+            val invalidCodeDefinition = serviceDefinition.copy(requestCode = "")
+            val invalidService = service.copy(serviceDefinition = invalidCodeDefinition)
+
+            val model = ServiceEditModel(invalidService)
+            model.validate() shouldBe false
+
+            model.codeValid shouldBe false
+        }
+    }
+
+    "editedService" should {
+        "return a correct service instance" {
+            val changedDefinition = ServiceDefinition(
+                name = "ChangedTestService",
+                multicastAddress = "231.1.1.9",
+                port = 8765,
+                requestCode = "StillAnybodyOutThere?"
+            )
+
+            val model = ServiceEditModel(service)
+            model.serviceName = changedDefinition.name
+            model.multicastAddress = changedDefinition.multicastAddress
+            model.port = changedDefinition.port.toString()
+            model.code = changedDefinition.requestCode
+            val changedService = model.editedService()
+
+            changedService shouldBe PersistentService(
+                serviceDefinition = changedDefinition,
+                lookupTimeout = null,
+                sendRequestInterval = null
+            )
+        }
+    }
+})
+
+/** A service definition for a test service. */
+private val serviceDefinition = ServiceDefinition(
+    name = "TestService",
+    multicastAddress = "231.0.0.8",
+    port = 9876,
+    requestCode = "AnybodyOutThere?"
+)
+
+/** A test service that should be edited. */
+private val service = PersistentService(
+    serviceDefinition = serviceDefinition,
+    lookupTimeout = null,
+    sendRequestInterval = null
+)

--- a/domain/src/main/java/com/github/oheger/wificontrol/domain/model/LookupConfig.kt
+++ b/domain/src/main/java/com/github/oheger/wificontrol/domain/model/LookupConfig.kt
@@ -44,9 +44,9 @@ data class LookupConfig(
 ) {
     companion object {
         /** A default value for the [lookupTimeout] property. */
-        val DEFAULT_LOOKUP_TIMEOUT = 30.seconds
+        val DEFAULT_LOOKUP_TIMEOUT = 15.seconds
 
         /** A default value for the [sendRequestInterval] property. */
-        val DEFAULT_SEND_REQUEST_INTERVAL = 500.milliseconds
+        val DEFAULT_SEND_REQUEST_INTERVAL = 250.milliseconds
     }
 }


### PR DESCRIPTION
When creating or editing services, user input is now validated, and corresponding messages are shown for properties with invalid values.

Also, the properties to customize the service discovery operation can now be entered.